### PR TITLE
Update paint-it-black.js

### DIFF
--- a/patch/optional/paint-it-black.js
+++ b/patch/optional/paint-it-black.js
@@ -3,6 +3,8 @@ module.exports = {
 	name: 'Paint It Black (experimental)',
 	description: 'The only thing visible in the game is Simon, enemies, stairs, and a few visual cues',
 	patch: [
+		{ offset: 0x01CAC9, bytes: '0F 16 06 0F 0F 16 06 0F 0F 0F 0F 0F 0F 00 05 0F' },
+		{ offset: 0x01CA8F, bytes: '0F 16 06 16 0F 16 06 0F 0F 16 06 0F 0F 0F 0F 0F' },
 		{
 			offset: 132706,
 			bytes: [


### PR DESCRIPTION
Extra touch of black and red to the title and game start screen. (will be overridden if a custom palette is used though unfortunately)