### PR TITLE
Create gameboy.js

### DIFF
--- a/patch/palette/gameboy.js
+++ b/patch/palette/gameboy.js
@@ -1,0 +1,11 @@
+module.exports = {
+        id: 'gameboy',
+        name: 'gameboy',
+        description: 'Burb\'s gameboy palette',
+        patch: [
+                // Set PPU_MASK to use grayscale mode with green tint. (01011111)
+                // Default value: $1E / 00011110
+                { offset: 0x01C0C0, bytes: '5F' },
+                { offset: 0x01C6B6, bytes: '5F' },
+        ]
+};


### PR DESCRIPTION
Lazy palette mod. Set PPU_MASK to use grayscale mode with a green tint. 
Some things don't look great in grayscale (the entire night palette for example) so a 'full' gb-palette may be in order in the future.